### PR TITLE
Fix link to instructions to create your own list

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -31,7 +31,7 @@ Thank you for your suggestions!
 
 ## Creating your own awesome list
 
-To create your own list, check out the [instructions](create-list.md).
+To create your own list, check out the [instructions](https://github.com/sindresorhus/awesome/blob/master/create-list.md).
 
 ## Adding something to an awesome list
 


### PR DESCRIPTION
I changed the link to point to sindresorhus's repository, since the create-list.md file doesn't exist in this one. I found that repo by clicking on the awesome icon on the README.md page.