### PR TITLE
add link to Explore DDD talk recordings

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -73,6 +73,7 @@ The term was coined by Eric Evans in his book of the same title.
 - [SkillsCasts by SkillsMatter](https://skillsmatter.com/skillscasts) - Searching DDD returns various talks given by Greg Young, Alberto Brandolini, and Dan North, etc.
 - [Alberto Brandolini: Event Storming](https://www.youtube.com/watch?v=veTVAN0oEkQ&list=PLve553MhJLs4YkEnHmOjWJv0B-6WY0-JI) - A YouTube collection of talks given by Alberto Brandolini on Event Storming.
 - [Greg Young](https://www.youtube.com/watch?v=JHGkaShoyNs&list=PL5XpN_ZVafKLePdxruDfdfi-IiZtXz-k9) - A YouTube collection of various talks given by Greg Young.
+- [Explore DDD videos](https://www.youtube.com/channel/UCcpKGt6MVvz7dISXLlMGmag) - Recordings of the talks given at the Explore DDD conferece.
 
 ## Community Resources
 


### PR DESCRIPTION
Paul Rayner has begun publishing the recordings from last month's inaugural Explore DDD conference in Denver. I added a link to the conference's YouTube channel. Right now, it's just the keynotes, but the sessions are forthcoming.