### PR TITLE
Add Elixir event_bus library

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -190,6 +190,7 @@ The term was coined by Eric Evans in his book of the same title.
 - [Broadway](https://github.com/broadway/broadway) - Broadway is a (PHP) project providing infrastructure and testing helpers for creating CQRS and event sourced applications.
 - [shriek-fx](https://github.com/ElderJames/shriek-fx) - An simple,elegant and useful Domain-Driven Design and CQRS framework developed using .NET Core 2.0.
 - [Rails Event Store](https://railseventstore.org) - Rails Event Store (RES) is a library for publishing, consuming, storing and retrieving events. It's your best companion for going with an event-driven architecture for your Rails application.
+- [Event Bus](https://github.com/otobus/event_bus) - Traceable, extendable and minimalist event bus implementation for Elixir with built-in event store and event watcher based on ETS.
 
 ## Podcasts and Interviews
 


### PR DESCRIPTION
Traceable, extendable and minimalist event bus implementation for Elixir with built-in event store and event watcher based on ETS.