### PR TITLE
Added KanDDDinsky Youtube collection of talks.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -79,6 +79,7 @@ The term was coined by Eric Evans in his book of the same title.
 - [Alberto Brandolini: Event Storming](https://www.youtube.com/watch?v=veTVAN0oEkQ&list=PLve553MhJLs4YkEnHmOjWJv0B-6WY0-JI) - A YouTube collection of talks given by Alberto Brandolini on Event Storming.
 - [Greg Young](https://www.youtube.com/watch?v=JHGkaShoyNs&list=PL5XpN_ZVafKLePdxruDfdfi-IiZtXz-k9) - A YouTube collection of various talks given by Greg Young.
 - [Explore DDD videos](https://www.youtube.com/channel/UCcpKGt6MVvz7dISXLlMGmag) - Recordings of the talks given at the Explore DDD conferece.
+- [KanDDDinsky](https://www.youtube.com/channel/UCJCpnslPdb_Dl8DKokXC3HA) - A YouTube collection of talks given at KanDDDinsky.
 
 ## Community Resources
 


### PR DESCRIPTION
Even though KanDDDinsky conference link is added in the list in Conference section, the website does not provide the content of talks which are in a YouTube channel. 