### PR TITLE
Adding reference to a sample DDD project written in Kotlin

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -159,6 +159,7 @@ The term was coined by Eric Evans in his book of the same title.
 - [Event Sourcing and CQRS Sample](https://github.com/pilloPl/event-source-cqrs-sample) - Sample event sourced application with Command Query Responsibility Segregation
 - [wolkenkit Sample Applications](https://docs.wolkenkit.io/latest/media/sample-applications/wolkenkit-boards/) - A collection of DDD sample applications, such as TodoMVC, a geocaching app, collaborative boards, …
 - [DDDInventoryItemFSharp](https://github.com/eulerfx/DDDInventoryItemFSharp) - An idiomatic F# implementation of Domain-Driven Design
+- [Kotlin DDD Sample](https://github.com/fabriciorissetto/kotlin-ddd-sample) - Sample DDD/CQRS project written in Kotlin. 
 
 ## Libraries and Frameworks
 


### PR DESCRIPTION
Hi,

I'm adding a reference to a sample DDD/CQRS project written in Kotlin that also uses some of the libraries described along the readme, like Axon Framework.