### PR TITLE
Update link for Udi Dahan's Advanced Distributed Systems Design course

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,7 @@ The term was coined by Eric Evans in his book of the same title.
 - [Domain Language eLearning](http://elearn.domainlanguage.com/) - Using our video lessons with Eric Evans, author of the original book on Domain-Driven Design (DDD), teach yourself techniques for evolving practical models that improve your software — not just your documents.
 - [Greg Young's CQRS Class](http://subscriptions.viddler.com/GregYoung/) - These videos include the entirety of Greg Young's DDD, CQRS, and Event Sourcing class.
 - [Distilling Domain-Driven Design](https://forcomprehension.com/) - Vaughn Vernon's online training course.
-- [Advanced Distributed Systems Design](https://5757066.flickrocket.com/us/) - Live training from Udi Dahan.  Udi's live training schedule can be found [here](http://udidahan.com/training/).
+- [Advanced Distributed Systems Design](https://learn-particular.thinkific.com/courses/adsd-online) - Online training course from Udi Dahan.  Udi's live training schedule can be found [here](http://udidahan.com/training/).
 - [Nomad PHP](https://nomadphp.com/product/introduction-event-sourcing-cqrs/) - Introduction to Event Sourcing and CQRS.
 - [Event Sourcery](https://eventsourcery.com/) - Introduction to DDD, CQRS, and Event Sourcing.
 - [Mixter](https://github.com/DevLyon/mixter) - CQRS and Event Sourcing Koans.


### PR DESCRIPTION
Update link for Udi Dahan's Advanced Distributed Systems Design course as the old link was defunct and going to a squatted landing page.  The new link navigates to the landing page (branded with Udi's company, Particular Software) for the online course and can be directly purchased or trialled from there.

Updated the description to indicate that it's a online course rather than a live course.