### PR TITLE
Adds dry-python to Python section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -287,6 +287,7 @@ The term was coined by Eric Evans in his book of the same title.
 
 ### Python
 - [Eventsoucing in Python](https://github.com/johnbywater/eventsourcing) - Mature, stable Python library for event sourcing and DDD. Supports wide variety of databases, different kinds of orderings of domain events, application level encryption, snapshotting, optimistic concurrency control, and process events. Applications, and entire systems of applications, can be defined independently of infrastructure, and run in different ways (single threaded, multi-threaded, clocked, stepping, multi-process, actor model) and with different infrastructure.
+- [dry-python](https://github.com/dry-python) - A set of libraries for pluggable business logic components.
 
 ### Ruby
 - [Rails Event Store](https://railseventstore.org) - Rails Event Store (RES) is a library for publishing, consuming, storing and retrieving events. It's your best companion for going with an event-driven architecture for your Rails application.


### PR DESCRIPTION
`dry-python` consists of several independent libraries. Each of them serves a very specific purpose.
And the whole idea is based on providing better tooling for business logic and domain driven design.

Link: https://github.com/dry-python