### PR TITLE
Add Spine Event Engine framework to the JVM section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -288,6 +288,7 @@ The term was coined by Eric Evans in his book of the same title.
 - [JESA](https://github.com/yreynhout/JESA) -  Event sourced aggregates for Java.
 - [Lagom](https://www.lagomframework.com) - The Lagom Framework is a microservices framework for the Java Virtual Machine, with APIs for the Java and Scala languages. It includes an Event Sourcing/CQRS based persistence module.
 - [SeedStack's Business Framework](http://seedstack.org/docs/business/) - A set of building blocks that enable you to code business logic according to the Domain-Driven Design (DDD) approach.
+- [Spine Event Engine](https://spine.io/) - a CQRS/ES framework for building cloud applications. Defines Bounded Contexts with their Commands, Events, and Entity states in Protobuf. The backend logic is written in Java, on top of the Proto-generated code. Client code in Java, JS or Dart communicates with the backend via gRPC.
 
 ### PHP
 - [Broadway](https://github.com/broadway/broadway) - Broadway is a (PHP) project providing infrastructure and testing helpers for creating CQRS and event sourced applications.


### PR DESCRIPTION
[Spine Event Engine](https://spine.io/) is a framework for building cloud applications. It helps applying Domain-Driven Design faster and smarter, with less code.

Link to the repository: https://github.com/SpineEventEngine