### PR TITLE
Add Eventide Ruby and Message DB 

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -304,6 +304,7 @@ The term was coined by Eric Evans in his book of the same title.
 - [dry-python](https://github.com/dry-python) - A set of libraries for pluggable business logic components.
 
 ### Ruby
+- [Eventide](https://eventide-project.org) - Event Sourcing and Microservices Stack for Ruby. A set of libraries for writing event driven, autonomous services.
 - [Rails Event Store](https://railseventstore.org) - Rails Event Store (RES) is a library for publishing, consuming, storing and retrieving events. It's your best companion for going with an event-driven architecture for your Rails application.
 
 ## Podcasts and Interviews

--- a/readme.md
+++ b/readme.md
@@ -273,6 +273,7 @@ The term was coined by Eric Evans in his book of the same title.
 ### Databases
 - [Event Store](https://geteventstore.com) - The open-source, functional database with Complex Event Processing in JavaScript.
 - [Eventsourcing](https://eventsourcing.com) - Business event capture and querying framework.
+- [Message DB](https://github.com/message-db/message-db) - Microservice Native Event Store and Message Store for Postgres. A fully-featured event store and message store implemented in PostgreSQL for Pub/Sub, Event Sourcing, Messaging, and Evented Microservices applications.
 - [Serialized](https://serialized.io) - Complete platform for Event Sourcing & CQRS.
 
 ### Elixir


### PR DESCRIPTION
- Add a link to https://eventide-project.org, a project that provides libraries for writing event sourced service in Ruby. 
- Add a link to https://github.com/message-db/message-db, a fully-featured event store implemented in PostgreSQL.