### PR TITLE
Add DDD Toolbox to Tools section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -416,6 +416,7 @@ The term was coined by Eric Evans in his book of the same title.
 ## Tools
 
 - [Domain Storytelling](http://www.domainstorytelling.org/) - a knowledge-crunching technique that helps the people involved to familiarize themselves with the domain and work out a model that expresses their shared understanding. Available as a [print-out template](http://www.domainstorytelling.org/images/DST_Whiteboard-Kit.pdf), as well as open-source online tool, [WPS Modeler](https://www.wps.de/modeler) ([source](https://github.com/wps/domain-story-modeler)).
+- [DDD Toolbox](https://dddtoolbox.com) - Open-source collection of modern web-based tools including Domain Storytelling and Event Storming ([Source Code](https://github.com/poulainpi/ddd-toolbox)).
 
 ## License
 


### PR DESCRIPTION
This PR adds [DDD Toolbox](https://dddtoolbox.com) to the Tools section.

DDD Toolbox is an open-source collection of modern web-based tools for Domain-Driven Design practitioners, including:
- **Domain Storytelling** - Visualize domain knowledge through collaborative storytelling
- **Event Storming** - Rapidly discover business processes and identify domain boundaries

**Live demo:** https://dddtoolbox.com  
**Source code:** https://github.com/poulainpi/ddd-toolbox