### PR TITLE
Deveel Events framework to the .NET libraries section in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -318,6 +318,7 @@ The term was coined by Eric Evans in his book of the same title.
 - [Stringly.Typed](https://github.com/mission202/Stringly.Typed) - Making it easier to convert strings to/from .NET types.
 - [Xer.Cqrs](https://github.com/jeyjeyemem/Xer.Cqrs) - A simple library for creating applications based on the CQRS pattern with support for attribute routing and hosted handlers. Developed in C# targeting .NET Standard 1.0.
 - [Deveel Repository](https://github.com/deveel/deveel.repository) - A simple implementation of the Repository pattern for .NET, supporting MongoDB and Entity Framework, extending the model with further utilities (caching, paging, validation, etc.).
+- [Deveel Events](https:///events.deveel.org)- Provides an easy-to-use framework for the publication and subscription of events in .NET applications, supporting multiple messaging channels (eg. RabbitMQ, Azure Service Bus, etc.) and a variety of serialization formats (eg. JSON, XML, etc.).
 
 ### Databases
 - [Event Store](https://geteventstore.com) - The open-source, functional database with Complex Event Processing in JavaScript.


### PR DESCRIPTION
Reference to the open-source project [Deveel Events](https://events.deveel.org) framework for the publishing of events to multiple channels (eg. RabbitMQ, HTTP Webhooks, Azure Service Bus, etc.)  and management of event subscriptions (_planned_).