### PR TITLE
Add Casino Engine to JVM Sample Projects

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -256,6 +256,7 @@ The term was coined by Eric Evans in his book of the same title.
 
 ### JVM languages
 - [Akka CQRS ES Demo](https://github.com/mdonkers/akka-cqrs-es-demo) - Demo project to implement the CQRS and Event Sourcing patterns in Scala-Akka.
+- [Casino Engine](https://github.com/nekzabirov/IGaming-Game-Engine) - Production iGaming/casino engine in Kotlin/Ktor demonstrating Hexagonal Architecture with DDD and CQRS. Aggregates raise domain events, repository ports live in the domain layer, command and query handlers are wired through a Koin-discovered registry, and domain events are published to RabbitMQ after the write transaction commits. Apache 2.0.
 - [DDD By Examples - Library](https://github.com/ddd-by-examples/library) - sample project of a library driven by real business requirements. Modular monolith implemented with the help od DDD, BDD, EventStorming, Example Mapping, CQRS, and more.
 - [DDD Leaven](https://github.com/BottegaIT/ddd-leaven-v2) - DDD-CQRS sample v2.0 project that helps you with starting out advanced domain modeling using Spring, JPA and testing.
 - [DDD Workshop - Project Manager](https://github.com/mkopylec/project-manager) - "Do It Yourself" DDD workshop and a sample DDD application at the same time. Based on a project managing domain.


### PR DESCRIPTION
## Summary

Adds [Casino Engine](https://github.com/nekzabirov/IGaming-Game-Engine) to **Sample Projects → JVM languages**, in alphabetical order (after "Akka CQRS ES Demo", before "DDD By Examples - Library").

## Why this fits

Casino Engine is a production-grade open-source iGaming engine in Kotlin/Ktor that demonstrates a full DDD + CQRS + Hexagonal Architecture in a real-world domain:

- **DDD**: pure domain layer (aggregates, value objects, sealed exception hierarchy, repository interfaces in \`domain/repository/\`), domain events raised from aggregates with \`WithEvents<T>\` for immutable mutators
- **CQRS**: commands vs queries with a Bus, auto-discovered handlers via Koin, separate read-model view types co-located with queries
- **Hexagonal**: ports in \`application/port/\`, adapters in \`infrastructure/\` (Exposed for persistence, RabbitMQ for events, S3 for files, gRPC clients for wallet)
- **Event-driven**: \`RabbitMqEventPublisher\` does an exhaustive \`when (event)\` over a sealed \`DomainEvent\` hierarchy — compile-time guarantee that every event has a mapping

Production-tested on moonbet.casino and 2k.ua. Apache 2.0.

There are very few public DDD + CQRS Kotlin samples at this scale — most JVM entries in the list are Scala/Akka or Java/Spring; this fills the Kotlin + Ktor gap with a non-trivial domain.

## Checklist

- [x] One pull request for one suggestion
- [x] Title-case PR title
- [x] Format \`[List Name](link) - Description.\`
- [x] Alphabetical placement
- [x] Useful description