### PR TITLE
Add Stratara to .NET Libraries and Frameworks

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -314,6 +314,7 @@ The term was coined by Eric Evans in his book of the same title.
 - [Projac](https://github.com/yreynhout/Projac) - Projac is a set of projection libraries that allow you to write projections targetting various backing stores.
 - [shriek-fx](https://github.com/ElderJames/shriek-fx) - An simple,elegant and useful Domain-Driven Design and CQRS framework developed using .NET Core 2.0.
 - [SqlStreamStore](https://github.com/damianh/SqlStreamStore) - .NET Stream Store library targeting SQL based implementations.
+- [Stratara](https://github.com/yesbert/Stratara) - CQRS and Event Sourcing framework for .NET with tamper-evident streams and tenant-aware encryption, plus integrated mediator, outbox, sagas and projections.
 - [Streamstone](https://github.com/yevhen/Streamstone) - Event Store for Azure Table Storage.
 - [Stringly.Typed](https://github.com/mission202/Stringly.Typed) - Making it easier to convert strings to/from .NET types.
 - [Xer.Cqrs](https://github.com/jeyjeyemem/Xer.Cqrs) - A simple library for creating applications based on the CQRS pattern with support for attribute routing and hosted handlers. Developed in C# targeting .NET Standard 1.0.


### PR DESCRIPTION
Adds [Stratara](https://github.com/yesbert/Stratara) — an integrated CQRS + Event Sourcing stack for .NET 10.

What sets it apart from the frameworks already listed: event streams are hash-chained, so you can prove an audit log wasn't tampered with, and per-tenant payload encryption is built in (AES-GCM with the tenant id as AAD) rather than bolted on. Mediator, transactional outbox, sagas, projections and identity all ship in one lockstep-versioned package family — no composition tax from wiring five libraries together.

- Project: https://github.com/yesbert/Stratara
- Docs: https://docs.stratara.tech
- NuGet: `dotnet add package Stratara.Mediator` (20 packages, all public)

Actively maintained, documented, and test-covered. Source-available under FSL-1.1-MIT (converts to MIT after two years).

Placed alphabetically in the .NET section (between SqlStreamStore and Streamstone).