### PR TITLE
Add Go DDD Template to Go Sample Projects

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -206,6 +206,7 @@ The term was coined by Eric Evans in his book of the same title.
 - [DDD Food App](https://github.com/victorsteven/food-app-server) - Sample DDD application implementing the 4 layers (Domain, Infrastructure, Application and Interface) and considering two domain patterns. There's a blog article written for it [here](https://dev.to/stevensunflash/using-domain-driven-design-ddd-in-golang-3ee5).
 - [DDD Sample in GO](https://github.com/takashabe/go-ddd-sample) - Just another sample application implementing the four layers of DDD.
 - [Evolutive CRUD API](https://github.com/friendsofgo/gopherapi) - API implementation with full CRUD using a SOLID, Hexagonal Architecture. There is a series of blog post written for it at <https://blog.friendsofgo.tech/>.
+- [Go DDD Template](https://github.com/sklinkert/go-ddd) - Production-grade DDD and CQRS template with value objects, race-safe idempotent commands, domain events with a transactional outbox, and a tutorial series teaching DDD from zero.
 - [Simple Hexagonal Architecture PoC API](https://github.com/tomiok/patients-API) - PoC for a patients API using the hexagonal architecture pattern.
 - [Azure DDD boilerplate](https://github.com/joshpme/azure-go-ddd-boilerplate) - A boilerplate project for DDD in Azure using a custom handler and Cosmos DB for event sourcing
 


### PR DESCRIPTION
Adding [Go DDD Template](https://github.com/sklinkert/go-ddd) to Sample Projects → GO.

Why it's a useful addition to the list:

- Production-grade patterns rather than a minimal demo: validated entities, a `Money` value object, race-safe idempotency keys (atomic reservation via `INSERT ... ON CONFLICT`), and domain events with a transactional outbox...  all with tests, including testcontainers-based integration tests against real Postgres.
- Ships with a nine-chapter tutorial teaching DDD from zero, with every chapter anchored to the actual code.
- Actively maintained (v1.0.0 released this month), MIT licensed, ~750 stars, also listed on awesome-go.

See discussion on redit as well: https://www.reddit.com/r/golang/comments/1uz2943/ddd_i_wrote_a_free_9chapter_tutorial_on/